### PR TITLE
Allow nesting of TextInput inside other components

### DIFF
--- a/form.js
+++ b/form.js
@@ -4,19 +4,26 @@ import { View } from 'react-native';
 export default class Form extends React.Component {
   constructor() {
     super();
+    this.count = 0;
     this.inputs = [];
   }
 
-  renderChildren(children) {
+  renderChildren(children, context) {
+    const that = context;
+
     return React.Children.map(children, (child, index) => {
-      if (child.children)
-        return React.cloneElement(child, this.renderChildren(child.children));
-      if (child.type.name !== 'TextInput') return child;
+      const countClone = that.count;
+      const componentName = child.type.displayName || child.type.name
+
+      if (child.props.children)
+        return React.cloneElement(child, { children: this.renderChildren(child.props.children, that) });
+      if (componentName !== 'TextInput') return child;
+      that.count = that.count + 1;
 
       return React.cloneElement(child, {
         onEnter: () =>
-          this.inputs[index + 1] ? this.inputs[index + 1].focus() : null,
-        inputRef: ref => (this.inputs[index] = ref),
+          that.inputs[countClone + 1] ? that.inputs[countClone + 1].focus() : null,
+        inputRef: ref => (that.inputs[countClone] = ref),
       });
     });
   }
@@ -25,7 +32,7 @@ export default class Form extends React.Component {
     let { children, ...props } = this.props;
     return (
       <View {...props}>
-        {this.renderChildren(children)}
+        {this.renderChildren(children, this)}
       </View>
     );
   }


### PR DESCRIPTION
This adds support for something like:

```js
<Form>
  <View style={[styles.textContainer, { marginTop: 30 }]}>
    <TextInput
      placeholder={'XXX'}
      {...textInputSharedProps}
      value={this.state.xxx}
      onChangeText={text => this.setState({ xxx: text })}
    />
  </View>
  <View style={[styles.textContainer, { marginTop: 12 }]}>
    <TextInput
      placeholder={'XX'}
      {...textInputSharedProps}
      value={this.state.xx}
      onSubmitEditing={this.joinXX}
      onChangeText={text => this.setState({ xx: text })}
    />
  </View>
</Form>
```