### PR TITLE
Fixes null reference error in form.js

### DIFF
--- a/form.js
+++ b/form.js
@@ -9,7 +9,7 @@ export default class Form extends React.Component {
 
   renderChildren(children, recursiveIndex = 0) {
     return React.Children.map(children, (child, index) => {
-      if(child === null)
+      if(!child)
         return;
       if (child.props.children)
         return React.cloneElement(child, {

--- a/form.js
+++ b/form.js
@@ -9,6 +9,8 @@ export default class Form extends React.Component {
 
   renderChildren(children, recursiveIndex = 0) {
     return React.Children.map(children, (child, index) => {
+      if(child === null)
+        return;
       if (child.props.children)
         return React.cloneElement(child, {
           ...child.props, 


### PR DESCRIPTION
This fixes an error that occurred when a `TextInput` is conditionally rendered within a `Form`.